### PR TITLE
added NuGetReferenceHintPathRewrite to projects for fix reference paths

### DIFF
--- a/Acumatica.Auth/Acumatica.Auth.csproj
+++ b/Acumatica.Auth/Acumatica.Auth.csproj
@@ -69,6 +69,7 @@ OpenAPI spec version: 1
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="NuGetReferenceHintPathRewrite.targets" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -78,4 +79,5 @@ OpenAPI spec version: 1
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="NuGetReferenceHintPathRewrite.targets" />
 </Project>

--- a/Acumatica.Auth/NuGetReferenceHintPathRewrite.targets
+++ b/Acumatica.Auth/NuGetReferenceHintPathRewrite.targets
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <PropertyGroup>
+    <HintPathPackageDir Condition="'$(HintPathPackageDir)' == ''">$( [System.IO.Path]::Combine( $(SolutionDir) , 'packages' ) )</HintPathPackageDir>
+  </PropertyGroup>
+  
+  <Target Name="ReplaceHintPathPackageDirForAssemblyReferences" BeforeTargets="ResolveAssemblyReferences">
+
+    <PropertyGroup>
+      <_HintPathPackagePattern>(?i)^(.+\\)?packages\\</_HintPathPackagePattern>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <_HintPathPackageDirReference Include="@(Reference)" 
+                                    Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' ">
+        <HintPath>$( [System.IO.Path]::Combine( $(HintPathPackageDir) , $( [System.Text.RegularExpressions.Regex]::Replace( %(Reference.HintPath) , $(_HintPathPackagePattern) , '' ) ) ) )</HintPath>
+      </_HintPathPackageDirReference>
+
+      <Reference Remove="@(Reference)"
+                 Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' " />
+      <Reference Include="@(_HintPathPackageDirReference)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/Acumatica.Auth/packages.config
+++ b/Acumatica.Auth/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="JsonSubTypes" version="1.6.0" targetFramework="net472" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" developmentDependency="true" />
+  <package id="NuGetReferenceHintPathRewrite" version="0.1.1" targetFramework="net472" developmentDependency="true" />
   <package id="RestSharp" version="106.10.1" targetFramework="net472" developmentDependency="true" />
 </packages>

--- a/Acumatica.Default_18.200.001/Acumatica.Default_18.200.001.csproj
+++ b/Acumatica.Default_18.200.001/Acumatica.Default_18.200.001.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="NuGetReferenceHintPathRewrite.targets" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -645,4 +646,5 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="NuGetReferenceHintPathRewrite.targets" />
 </Project>

--- a/Acumatica.Default_18.200.001/NuGetReferenceHintPathRewrite.targets
+++ b/Acumatica.Default_18.200.001/NuGetReferenceHintPathRewrite.targets
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <PropertyGroup>
+    <HintPathPackageDir Condition="'$(HintPathPackageDir)' == ''">$( [System.IO.Path]::Combine( $(SolutionDir) , 'packages' ) )</HintPathPackageDir>
+  </PropertyGroup>
+  
+  <Target Name="ReplaceHintPathPackageDirForAssemblyReferences" BeforeTargets="ResolveAssemblyReferences">
+
+    <PropertyGroup>
+      <_HintPathPackagePattern>(?i)^(.+\\)?packages\\</_HintPathPackagePattern>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <_HintPathPackageDirReference Include="@(Reference)" 
+                                    Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' ">
+        <HintPath>$( [System.IO.Path]::Combine( $(HintPathPackageDir) , $( [System.Text.RegularExpressions.Regex]::Replace( %(Reference.HintPath) , $(_HintPathPackagePattern) , '' ) ) ) )</HintPath>
+      </_HintPathPackageDirReference>
+
+      <Reference Remove="@(Reference)"
+                 Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' " />
+      <Reference Include="@(_HintPathPackageDirReference)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/Acumatica.Default_18.200.001/packages.config
+++ b/Acumatica.Default_18.200.001/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="JsonSubTypes" version="1.6.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="NuGetReferenceHintPathRewrite" version="0.1.1" targetFramework="net472" developmentDependency="true" />
   <package id="RestSharp" version="106.10.1" targetFramework="net472" />
 </packages>

--- a/Acumatica.RESTClient/Acumatica.RESTClient.csproj
+++ b/Acumatica.RESTClient/Acumatica.RESTClient.csproj
@@ -101,8 +101,10 @@ OpenAPI spec version: 3
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="NuGetReferenceHintPathRewrite.targets" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MsBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="NuGetReferenceHintPathRewrite.targets" />
 </Project>

--- a/Acumatica.RESTClient/NuGetReferenceHintPathRewrite.targets
+++ b/Acumatica.RESTClient/NuGetReferenceHintPathRewrite.targets
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+
+  <PropertyGroup>
+    <HintPathPackageDir Condition="'$(HintPathPackageDir)' == ''">$( [System.IO.Path]::Combine( $(SolutionDir) , 'packages' ) )</HintPathPackageDir>
+  </PropertyGroup>
+  
+  <Target Name="ReplaceHintPathPackageDirForAssemblyReferences" BeforeTargets="ResolveAssemblyReferences">
+
+    <PropertyGroup>
+      <_HintPathPackagePattern>(?i)^(.+\\)?packages\\</_HintPathPackagePattern>
+    </PropertyGroup>
+    
+    <ItemGroup>
+      <_HintPathPackageDirReference Include="@(Reference)" 
+                                    Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' ">
+        <HintPath>$( [System.IO.Path]::Combine( $(HintPathPackageDir) , $( [System.Text.RegularExpressions.Regex]::Replace( %(Reference.HintPath) , $(_HintPathPackagePattern) , '' ) ) ) )</HintPath>
+      </_HintPathPackageDirReference>
+
+      <Reference Remove="@(Reference)"
+                 Condition=" '%(Reference.HintPath)' != '' and '$( [System.Text.RegularExpressions.Regex]::IsMatch( %(Reference.HintPath) , $(_HintPathPackagePattern) ) )' == 'true' " />
+      <Reference Include="@(_HintPathPackageDirReference)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/Acumatica.RESTClient/packages.config
+++ b/Acumatica.RESTClient/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="JsonSubTypes" version="1.6.0" targetFramework="net472" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" developmentDependency="true" />
+  <package id="NuGetReferenceHintPathRewrite" version="0.1.1" targetFramework="net472" developmentDependency="true" />
   <package id="RestSharp" version="106.10.1" targetFramework="net472" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
We faced the problem of finding nuget packages when adding the AcumaticaRESTAPIClientForCSharp solution to our solution. Adding NuGetReferenceHintPathRewrite packages automatically resolves this issue