### PR TITLE
Resolved errors in RestExample.cs, OdataExample.cs files. 

### DIFF
--- a/Acumatica REST API Console Application/ODataExample.cs
+++ b/Acumatica REST API Console Application/ODataExample.cs
@@ -45,7 +45,9 @@ namespace AcumaticaRestApiExample
 			Console.WriteLine("Retrieve the modified stocks qtys with OData Version 3");
 			string filterParam = "LastModifiedDateTime gt datetime'2022-07-13T00:00:00.000'";
 			response = odatav3.GetOData("DB-StorageDetails", filter: filterParam);
-			Console.WriteLine(response.Data);
+            ///gives this error:
+            ///<m:message>Could not find a property named 'LastModifiedDateTime' on type 'PX.Data.DBStorageDetails'.</m:message>
+            Console.WriteLine(response.Data);
 		}
         
 		public static void ODataGetV4(string siteURL, string username, string password, string tenant)

--- a/Acumatica REST API Console Application/Program.cs
+++ b/Acumatica REST API Console Application/Program.cs
@@ -4,14 +4,14 @@ namespace AcumaticaRestApiExample
 {
 	class Program
 	{
-		const string SiteURL = "http://localhost/22r203/";
+		const string SiteURL = "http://localhost/22r193/";
         const string Username = "admin";
 		const string Password = "123";
-		const string Tenant = "Company";
+		const string Tenant = null;
 		const string Branch = null;
 		const string Locale = null;
-        private const string ClientSecret = "Op0M23KPx8BWvQHWQAvbMg";
-        private const string ClientID = "85D663A7-9BDC-4409-E5A0-D686D28CF4BB@Company";
+        private const string ClientSecret = "Bwe_jPnrRBUjn2Ish1rZ1w";
+        private const string ClientID = "D1734A18-6EBC-A44F-BAD4-E2E5ACC978D6@Company";
         const string RedirectUrl = "https://localhost/urlForOauth/";
 
         static void Main(string[] args)

--- a/Acumatica.RESTClient.Customization/CustomizationApi.cs
+++ b/Acumatica.RESTClient.Customization/CustomizationApi.cs
@@ -43,6 +43,7 @@ namespace Acumatica.RESTClient.CustomizationApi
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(customizationImport),
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json)).Result;
@@ -166,6 +167,7 @@ namespace Acumatica.RESTClient.CustomizationApi
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(publishParams),
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json)).Result;
@@ -178,6 +180,7 @@ namespace Acumatica.RESTClient.CustomizationApi
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 "/CustomizationApi/PublishEnd",
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json)).Result;

--- a/Acumatica.RESTClient.OData/ODataAPI.cs
+++ b/Acumatica.RESTClient.OData/ODataAPI.cs
@@ -28,7 +28,8 @@ namespace Acumatica.RESTClient.ODataApi
             //Oauth authentication
             HttpResponseMessage response = ApiClient.CallApiAsync(
                 ConfigurePath(resource),
-                HttpMethod.Get,  
+                HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, null, skip, top),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.Json),
@@ -52,9 +53,9 @@ namespace Acumatica.RESTClient.ODataApi
         {
             return string.IsNullOrEmpty(Tenant) 
                  ?
-                 $"{ApiClient.BasePath}/{Version}/{resource}" 
+                 $"{Version}/{resource}" 
                  : 
-                 $"{ApiClient.BasePath}/{Version}/{Tenant}/{resource}";
+                 $"{Version}/{Tenant}/{resource}";
         }
 
         private Dictionary<string, string> ComposeAuthenticationHeaders()

--- a/Acumatica.RESTClient/AuthApi/AuthApi.cs
+++ b/Acumatica.RESTClient/AuthApi/AuthApi.cs
@@ -194,6 +194,7 @@ namespace Acumatica.Auth.Api
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ApiClientHelpers.ToFormUrlEncoded(new Dictionary<string, string>()
                 {
                     {"grant_type", "refresh_token" },
@@ -211,12 +212,13 @@ namespace Acumatica.Auth.Api
 
         protected ApiResponse<Token> ConnectWithHttpInfo(string clientID, string clientSecret, string username, string password, OAuthScope scope)
         {
-            var localVarPath = "/identity/connect/token";
+            var localVarPath = "identity/connect/token";
 
             // make the HTTP request
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ApiClientHelpers.ToFormUrlEncoded(new Dictionary<string, string>
                 {
                     {"grant_type", "password" },
@@ -246,6 +248,7 @@ namespace Acumatica.Auth.Api
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.None),
                 ComposeContentHeaders(HeaderContentType.WwwForm)).Result;
@@ -263,6 +266,7 @@ namespace Acumatica.Auth.Api
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 localVarPath,
                 HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ApiClientHelpers.ToFormUrlEncoded(new Dictionary<string, string>
                 {
                     {"grant_type", "authorization_code" },
@@ -306,7 +310,8 @@ namespace Acumatica.Auth.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 "/entity/auth/login",
-                HttpMethod.Post, 
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(credentials), 
                 ComposeAcceptHeaders(HeaderContentType.None), 
                 ComposeContentHeaders(HeaderContentType.Json | HeaderContentType.Xml | HeaderContentType.WwwForm)).Result;
@@ -329,7 +334,8 @@ namespace Acumatica.Auth.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 "/entity/auth/login",
-                HttpMethod.Post,  
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(credentials), 
                 ComposeAcceptHeaders(HeaderContentType.None), 
                 ComposeContentHeaders(HeaderContentType.Json | HeaderContentType.Xml | HeaderContentType.WwwForm));
@@ -349,7 +355,8 @@ namespace Acumatica.Auth.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 "/entity/auth/logout",
-                HttpMethod.Post, 
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.None), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -369,7 +376,8 @@ namespace Acumatica.Auth.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 "/entity/auth/logout",
-                HttpMethod.Post, 
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.None),
                 ComposeContentHeaders(HeaderContentType.None));

--- a/Acumatica.RESTClient/BaseApi/BaseApi.cs
+++ b/Acumatica.RESTClient/BaseApi/BaseApi.cs
@@ -118,6 +118,28 @@ namespace Acumatica.RESTClient.Api
             return localVarHttpHeaderAccepts;
         }
 
+        /// <summary>
+        /// Composes Query Parameters for API Request. 
+        /// </summary>
+        /// <param name="select">The fields of the entity to be returned from the system. (optional)</param>
+        /// <param name="filter">The conditions that determine which records should be selected from the system. (optional)</param>
+        /// <param name="expand">The linked and detail entities that should be expanded. (optional)</param>
+        /// <param name="custom">The fields that are not defined in the contract of the endpoint to be returned from the system. (optional)</param>
+        /// <param name="skip">The number of records to be skipped from the list of returned records. (optional)</param>
+        /// <param name="top">The number of records to be returned from the system. (optional)</param>
+        protected List<KeyValuePair<string, string>> ComposeQueryParams(string select = null, string filter = null, string expand = null, string custom = null, int? skip = null, int? top = null)
+        {
+            var queryParameters = ComposeEmptyQueryParams();
+            if (!String.IsNullOrEmpty(select)) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$select", select)); // query parameter
+            if (!String.IsNullOrEmpty(filter)) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$filter", filter)); // query parameter
+            if (!String.IsNullOrEmpty(expand)) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$expand", expand)); // query parameter
+            if (!String.IsNullOrEmpty(custom)) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$custom", custom)); // query parameter
+            if (skip != null) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$skip", skip)); // query parameter
+            if (top != null) queryParameters.AddRange(ApiClient.ParameterToKeyValuePairs("", "$top", top)); // query parameter
+
+            return queryParameters;
+        }
+
         protected object ComposeBody(object objectForRequestBody)
         {
             object postBody = null;
@@ -133,6 +155,20 @@ namespace Acumatica.RESTClient.Api
 
             return postBody;
         }
+
+        protected List<KeyValuePair<string, string>> ComposeEmptyQueryParams()
+        {
+            return new List<KeyValuePair<String, String>>();
+        }
+        protected Dictionary<string, string> ComposeEmptyPathParams()
+        {
+            return new Dictionary<String, String>();
+        }
+        protected Dictionary<string, string> ComposeEmptyFormParams()
+        {
+            return new Dictionary<String, String>();
+        }
+
         protected ApiResponse<T> DeserializeResponse<T>(HttpResponseMessage response)
         {
             int localVarStatusCode = (int)response.StatusCode;

--- a/Acumatica.RESTClient/BaseApi/EntityAPI_Implementation.cs
+++ b/Acumatica.RESTClient/BaseApi/EntityAPI_Implementation.cs
@@ -38,7 +38,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}/files/{filename}",
-                HttpMethod.Put, 
+                HttpMethod.Put,
+                ComposeEmptyQueryParams(),
                 content, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.OctetStream)).Result ;
@@ -64,7 +65,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}/files/{filename}",
-                HttpMethod.Put, 
+                HttpMethod.Put,
+                ComposeEmptyQueryParams(),
                 content, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.OctetStream));
@@ -92,7 +94,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{action.GetType().Name}",
-                HttpMethod.Post, 
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(action), 
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json),
@@ -119,7 +122,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{action.GetType().Name}",
-                HttpMethod.Post, 
+                HttpMethod.Post,
+                ComposeEmptyQueryParams(),
                 ComposeBody(action),
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json),
@@ -141,6 +145,7 @@ namespace Acumatica.RESTClient.Api
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"/{GetEndpointPath()}/{parsedLocation.EntityName}/{parsedLocation.ActionName}/{parsedLocation.Status}/{parsedLocation.ID}",
                 HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -176,7 +181,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}",
-                HttpMethod.Put, 
+                HttpMethod.Put,
+                ComposeQueryParams(select, filter, expand, custom),
                 ComposeBody(entity),
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json),
@@ -208,6 +214,7 @@ namespace Acumatica.RESTClient.Api
 			HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}",
 				HttpMethod.Put, 
+                ComposeQueryParams(select, filter, expand, custom),
                 ComposeBody(entity),
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.Json),
@@ -261,7 +268,8 @@ namespace Acumatica.RESTClient.Api
             // make the HTTP request
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None));
@@ -288,7 +296,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json),     
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -316,6 +325,7 @@ namespace Acumatica.RESTClient.Api
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}",
                 HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.None),
@@ -345,6 +355,7 @@ namespace Acumatica.RESTClient.Api
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}",
                 HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.Json),
                 ComposeContentHeaders(HeaderContentType.None),
@@ -372,7 +383,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{id}",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None));
@@ -399,7 +411,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{id}",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeQueryParams(select, filter, expand, custom),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -421,7 +434,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/$adHocSchema",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None));
@@ -440,7 +454,8 @@ namespace Acumatica.RESTClient.Api
         {
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/$adHocSchema",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -465,7 +480,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}",
-                HttpMethod.Delete, 
+                HttpMethod.Delete,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Any), 
                 ComposeContentHeaders(HeaderContentType.None));
@@ -488,7 +504,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{string.Join("/", ids)}",
-                HttpMethod.Delete, 
+                HttpMethod.Delete,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Any), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -511,7 +528,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{id}",
-                HttpMethod.Delete, 
+                HttpMethod.Delete,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Any), 
                 ComposeContentHeaders(HeaderContentType.None));
@@ -534,7 +552,8 @@ namespace Acumatica.RESTClient.Api
 
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"{GetEndpointPath()}/{GetEntityName()}/{id}",
-                HttpMethod.Delete, 
+                HttpMethod.Delete,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Any), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;

--- a/Acumatica.RESTClient/FileApi/FileApi.cs
+++ b/Acumatica.RESTClient/FileApi/FileApi.cs
@@ -33,6 +33,7 @@ namespace Acumatica.RESTClient.FileApi
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 $"/entity/{endpointName}/{endpointVersion}/files/{fileID}",
                 HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null,
                 ComposeAcceptHeaders(HeaderContentType.OctetStream),
                 ComposeContentHeaders(HeaderContentType.Json)

--- a/Acumatica.RESTClient/RootApi/RootApi.cs
+++ b/Acumatica.RESTClient/RootApi/RootApi.cs
@@ -69,7 +69,8 @@ namespace Acumatica.RESTClient.RootApi
         {
             HttpResponseMessage localVarResponse = ApiClient.CallApiAsync(
                 "/entity",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Xml | HeaderContentType.Json), 
                 ComposeContentHeaders(HeaderContentType.None)).Result;
@@ -89,7 +90,8 @@ namespace Acumatica.RESTClient.RootApi
         {
             HttpResponseMessage localVarResponse = await ApiClient.CallApiAsync(
                 "/entity",
-                HttpMethod.Get, 
+                HttpMethod.Get,
+                ComposeEmptyQueryParams(),
                 null, 
                 ComposeAcceptHeaders(HeaderContentType.Json | HeaderContentType.Xml),     
                 ComposeContentHeaders(HeaderContentType.None));


### PR DESCRIPTION
included query parameter function in Rest Api requests, removed extra '/' symbol from oauth and odata requests while composing the path. OdataV3 last example gives 500 error. I do not have access to endpoint to run ExtendedEndpointExample. 