### PR TITLE
Allow configuration of HTTP client factory via DI to allow for configuration of e.g. retry policies

### DIFF
--- a/Acumatica.RESTClient/Client/ApiClient.cs
+++ b/Acumatica.RESTClient/Client/ApiClient.cs
@@ -45,11 +45,12 @@ namespace Acumatica.RESTClient.Client
         /// <param name="ignoreSslErrors">
         /// Sets whether SSL/TLS related errors should be ignored.
         /// </param>
-        public ApiClient(string basePath,
+        public ApiClient(
+            string basePath,
             int timeout = 100000,
             bool ignoreSslErrors = false,
-             Action<HttpRequestMessage>? requestInterceptor = null,
-             Action<HttpResponseMessage>? responseInterceptor = null)
+            Action<HttpRequestMessage>? requestInterceptor = null,
+            Action<HttpResponseMessage>? responseInterceptor = null)
         {
             BasePath = basePath.EndsWith("/") ? basePath : basePath + "/";
 
@@ -59,13 +60,21 @@ namespace Acumatica.RESTClient.Client
             HttpClient = new HttpClientHandler(timeout, ignoreSslErrors);
         }
 
-        internal ApiClient(string basePath, IHttpClientHandler httpClient)
+        public ApiClient(
+            string basePath,
+            IHttpClientHandler httpClient,
+            Action<HttpRequestMessage>? requestInterceptor = null,
+            Action<HttpResponseMessage>? responseInterceptor = null)
         {
-            BasePath = basePath.EndsWith("/") ? basePath : basePath + "/";
+            BasePath = basePath.EndsWith("/")
+                ? basePath
+                : basePath + "/";
+
+            RequestInterceptor = requestInterceptor;
+            ResponseInterceptor = responseInterceptor;
 
             HttpClient = httpClient;
         }
-
 
         /// <summary>
         /// Method that is executed before request. May be used for loggin the request body.
@@ -212,14 +221,14 @@ namespace Acumatica.RESTClient.Client
 
             if (postBody != null)
             {
-                if (postBody is string)
+                if (postBody is string str)
                 {
-                    request.Content = new StringContent(postBody as string, Encoding.UTF8, contentType);
+                    request.Content = new StringContent(str, Encoding.UTF8, contentType);
                 }
 
-                else if (postBody is byte[])
+                else if (postBody is byte[] bytes)
                 {
-                    request.Content = new ByteArrayContent(postBody as byte[]);
+                    request.Content = new ByteArrayContent(bytes);
                 }
                 else
                 {

--- a/Acumatica.RESTClient/Client/HttpClientHandler.cs
+++ b/Acumatica.RESTClient/Client/HttpClientHandler.cs
@@ -7,76 +7,55 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("RESTClientTests")]
-
 namespace Acumatica.RESTClient.Client
 {
-    internal class HttpClientHandler : IHttpClientHandler
+    public class HttpClientHandler : IHttpClientHandler
     {
-        private const string httpClientName = "HttpClient";
         private const string SessionCookieName = "ASP.NET_SessionId";
+        private readonly CookieContainer _cookieContainer;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly string _httpClientName;
+
+        public HttpClientHandler(
+            CookieContainer cookieContainer,
+            IHttpClientFactory httpClientFactory,
+            string httpClientName)
+        {
+            _cookieContainer = cookieContainer;
+            _httpClientFactory = httpClientFactory;
+            _httpClientName = httpClientName;
+        }
 
         public HttpClientHandler(
             int timeout,
             bool ignoreSslErrors)
         {
-            Cookies = new CookieContainer();
+            _httpClientName = "HttpClient";
 
-            var services = new ServiceCollection();
-            services.AddHttpClient(httpClientName, c => {
-                c.Timeout = new TimeSpan(0, 0, 0, 0, timeout);
-            }
-            ).ConfigurePrimaryHttpMessageHandler(() => {
-                System.Net.Http.HttpClientHandler handler;
-                if (ignoreSslErrors)
-                {
-                    handler = new System.Net.Http.HttpClientHandler
-                    {
-                        UseCookies = true,
-                        CookieContainer = Cookies,
-                        ServerCertificateCustomValidationCallback = (HttpRequestMessage httpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2 cert, System.Security.Cryptography.X509Certificates.X509Chain cetChain, System.Net.Security.SslPolicyErrors policyErrors) => true
-                    };
-                }
-                else
-                {
-                    handler = new System.Net.Http.HttpClientHandler
-                    {
-                        UseCookies = true,
-                        CookieContainer = Cookies
-                    };
-                }
-                return handler;
-            });
-            var serviceProvider = services.BuildServiceProvider();
-            HttpClientFactory = serviceProvider.GetService<IHttpClientFactory>()!;
+            var serviceProvider = new ServiceCollection()
+                .ConfigureDefaultHttpClientHandler(
+                    timeout,
+                    ignoreSslErrors,
+                    _httpClientName)
+                .BuildServiceProvider();
+
+            _httpClientFactory = serviceProvider
+                .GetRequiredService<IHttpClientFactory>();
+            _cookieContainer = serviceProvider
+                .GetRequiredService<CookieContainer>();
         }
 
-        public CookieContainer Cookies
-        {
-            get; protected set;
-        }
+        public Task<HttpResponseMessage> SendRequest(
+            HttpRequestMessage request) =>
+                GetHttpClient().SendAsync(request);
 
-        public IHttpClientFactory HttpClientFactory { get; set; }
+        public virtual HttpClient GetHttpClient() =>
+            _httpClientFactory.CreateClient(_httpClientName);
 
-
-        public async Task<HttpResponseMessage> SendRequest(HttpRequestMessage request)
-        {
-            return await GetHttpClient().SendAsync(request);
-        }
-
-        public virtual HttpClient GetHttpClient()
-        {
-            return HttpClientFactory.CreateClient(httpClientName);
-        }
-
-        public bool HasSessionCookie(Uri path, string sessionCookieName)
-        {
-            if (Cookies != null
-                && Cookies.GetCookies(path).Cast<Cookie>()
-                .Any(cookie => cookie.Name == sessionCookieName))
-            {
-                return true;
-            }
-            return false;
-        }
+        public bool HasSessionCookie(Uri path, string sessionCookieName) =>
+            _cookieContainer
+                .GetCookies(path)
+                .Cast<Cookie>()
+                .Any(cookie => cookie.Name == sessionCookieName);
     }
 }

--- a/Acumatica.RESTClient/Client/IHttpClientHandler.cs
+++ b/Acumatica.RESTClient/Client/IHttpClientHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Acumatica.RESTClient.Client
 {
-    internal interface IHttpClientHandler
+    public interface IHttpClientHandler
     {
         Task<HttpResponseMessage> SendRequest(HttpRequestMessage request);
         bool HasSessionCookie(Uri path, string sessionCookieName);

--- a/Acumatica.RESTClient/Extensions/ServiceCollectionExtensions.cs
+++ b/Acumatica.RESTClient/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Acumatica.RESTClient
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureAcumaticaHttpClientHandler(
+            this IServiceCollection serviceCollection,
+            string acumaticaHttpClientName) =>
+                serviceCollection.AddSingleton<Client.IHttpClientHandler>(
+                    sp => new Client.HttpClientHandler(
+                        sp.GetRequiredService<CookieContainer>(),
+                        sp.GetRequiredService<IHttpClientFactory>(),
+                        acumaticaHttpClientName));
+
+        public static IServiceCollection ConfigureDefaultHttpClientHandler(
+            this IServiceCollection serviceCollection,
+            int timeout = 100000,
+            bool ignoreSslErrors = false,
+            string httpClientName = "HttpClient")
+        {
+            var cookies = new CookieContainer();
+
+            serviceCollection
+                .AddSingleton(_ => cookies)
+                .AddHttpClient(
+                    httpClientName,
+                    c =>
+                    {
+                        c.Timeout = TimeSpan.FromMilliseconds(timeout);
+                    })
+                .ConfigurePrimaryHttpMessageHandler(
+                    () => ignoreSslErrors
+                        ? new HttpClientHandler
+                        {
+                            UseCookies = true,
+                            CookieContainer = cookies,
+                            ServerCertificateCustomValidationCallback =
+                                (_, _, _, _) => true,
+                        }
+                        : new HttpClientHandler
+                        {
+                            UseCookies = true,
+                            CookieContainer = cookies,
+                        });
+
+            return serviceCollection
+                .ConfigureAcumaticaHttpClientHandler(httpClientName);
+        }
+
+        public static IServiceCollection ConfigureDefaultApiClient(
+            this IServiceCollection serviceCollection,
+            string basePath,
+            int timeout = 100000,
+            bool ignoreSslErrors = false,
+            Action<HttpRequestMessage>? requestInterceptor = null,
+            Action<HttpResponseMessage>? responseInterceptor = null) =>
+                serviceCollection
+                    .ConfigureDefaultHttpClientHandler(timeout, ignoreSslErrors)
+                    .AddSingleton(sp =>
+                        new Client.ApiClient(
+                            basePath,
+                            sp.GetRequiredService<Client.IHttpClientHandler>(),
+                            requestInterceptor,
+                            responseInterceptor));
+    }
+}


### PR DESCRIPTION
Allow configuration of HTTP client factory via DI by consumers to allow for configuration of e.g. retry policies

Previously the HTTP client was buried in HttpClientHandler which built its own dependencies.

Usage of e.g. Polly for retries on 429 status codes is [most easily done in DI](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly).

Constructors are purely new for backwards compatibility.

Comes with extensions for DI to either use previous defaults or accommodate usage of own dependencies for IHttpClientFactory.

Does some other misc cleanup for usage of reflection.